### PR TITLE
Use rhai::CustomType to localize registration of methods

### DIFF
--- a/src/config/transmission.rs
+++ b/src/config/transmission.rs
@@ -2,22 +2,35 @@ use std::fmt;
 
 use crate::util::chrono_duration;
 use chrono::Duration;
-use rhai::EvalAltResult;
+use rhai::{CustomType, EvalAltResult, TypeBuilder};
 use serde::{Deserialize, Serialize};
 
 pub const DEFAULT_POLL_INTERVAL_MINS: i64 = 5;
 
 /// A transmission instance
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, CustomType)]
+#[rhai_type(extra = Self::build_rhai)]
 pub struct Transmission {
+    #[rhai_type(readonly)]
     pub url: String,
+    #[rhai_type(readonly)]
     pub user: Option<String>,
+    #[rhai_type(readonly)]
     pub password: Option<String>,
+    #[rhai_type(readonly)]
     #[serde(with = "chrono_duration")]
     pub poll_interval: Duration,
 }
 
 impl Transmission {
+    fn build_rhai(builder: &mut TypeBuilder<Self>) {
+        builder
+            .with_fn("transmission", Self::new)
+            .with_fn("user", Self::with_user)
+            .with_fn("password", Self::with_password)
+            .with_fn("poll_interval", Self::with_poll_interval);
+    }
+
     pub fn new(url: &str) -> Self {
         Self {
             url: url.to_string(),


### PR DESCRIPTION
This doesn't get rid of many lines of code, but it results in code that is more closely grouped together: each type is now responsible for registering its own methods with the rhai engine.