### PR TITLE
Use prometheus-client instead of the prometheus crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +359,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+
+[[package]]
 name = "enum-iterator"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,15 +520,14 @@ name = "gearbox-maintenance"
 version = "0.0.2-dev"
 dependencies = [
  "anyhow",
+ "axum",
  "chrono",
  "clap",
  "enum-kinds",
  "futures",
  "hhmmss",
- "once_cell",
  "parse_duration",
- "prometheus",
- "prometheus-hyper",
+ "prometheus-client",
  "rhai",
  "serde",
  "tempfile",
@@ -880,6 +939,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,40 +1169,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus"
-version = "0.13.4"
+name = "prometheus-client"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
 dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
+ "dtoa",
+ "itoa",
  "parking_lot",
- "protobuf",
- "thiserror 1.0.69",
+ "prometheus-client-derive-encode",
 ]
 
 [[package]]
-name = "prometheus-hyper"
-version = "0.2.0"
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4599cd06b4c85ba573bf2edf4e5ca5c3f32505ead7fb1f0c7d9a4b90195e1ab1"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "prometheus",
- "tokio",
- "tracing",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
-
-[[package]]
-name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quinn"
@@ -1152,7 +1204,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror",
  "tokio",
  "tracing",
 ]
@@ -1171,7 +1223,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1357,15 +1409,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -1513,6 +1564,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,12 +1674,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1823,31 +1878,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.11",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1995,6 +2030,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2015,6 +2051,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,14 @@ chrono = "0.4.40"
 url = "2.5.2"
 parse_duration = "2.1.1"
 enum-kinds = "0.5.1"
-prometheus = "0.13.4"
-prometheus-hyper = "0.2"
+prometheus-client = "0.23.1"
 futures = "0.3.31"
-once_cell = "1.20.3"
 hhmmss = "0.1.0"
 serde = "*"
 # For rhai, we have to exclude ahash for now, as that pins getrandom
 # at a version incompatible with the latest rustls bug fixes:
 rhai = { version = "1.19.0", features = ["serde", "std"], default_features = false }
+axum = "0.8.1"
 
 [dependencies.clap]
 features = ["derive"]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,87 +1,206 @@
-use once_cell::sync::Lazy;
-use prometheus::{
-    register_counter_vec, register_gauge_vec, register_histogram_vec, CounterVec, GaugeVec,
-    HistogramVec,
+use std::{sync::Arc, time::SystemTime};
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header::CONTENT_TYPE, Response, StatusCode},
+    response::IntoResponse,
+    routing::get,
+    Router,
 };
+use prometheus_client::{
+    encoding::{text::encode, EncodeLabelSet},
+    metrics::{
+        counter::Counter,
+        family::Family,
+        gauge::Gauge,
+        histogram::{exponential_buckets, Histogram},
+    },
+    registry::Registry,
+};
+use tokio::sync::Mutex;
 
-pub(crate) static TICK_DURATION: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "instance_fetch_duration_ms",
-        "Time it took gearbox-maintenance to fetch data from one transmission instance",
-        &["transmission_url"]
-    )
-    .unwrap()
-});
+pub(crate) struct TickDurationHandle {
+    family: Family<TransmissionLocation, Histogram>,
+    variant: TransmissionLocation,
+    started: SystemTime,
+}
 
-pub(crate) static TICK_FAILURES: Lazy<CounterVec> = Lazy::new(|| {
-    register_counter_vec!(
-        "instance_fetch_failure_count",
-        "Number of times that fetching from the instance failed",
-        &["transmission_url"]
-    )
-    .unwrap()
-});
-
-pub(crate) static TORRENT_SIZE_HIST: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "torrent_size_bytes_historam",
-        "Histogram of torrent size managed by policy.",
-        &["transmission_url", "policy"],
-        prometheus::exponential_buckets(0.5e9, 2.0, 11).unwrap() // 500MB, then up to 1 terabyte
-    )
-    .unwrap()
-});
-
-pub(crate) static TORRENT_COUNT: Lazy<GaugeVec> = Lazy::new(|| {
-    register_gauge_vec!(
-        "torrent_count",
-        "Number of torrents, per tracker.",
-        &["transmission_url", "policy"],
-    )
-    .unwrap()
-});
-
-pub(crate) static TORRENT_SIZES: Lazy<GaugeVec> = Lazy::new(|| {
-    register_gauge_vec!(
-        "torrent_size_bytes",
-        "Data size of torrents in bytes, per tracker.",
-        &["transmission_url", "policy"],
-    )
-    .unwrap()
-});
-
-pub(crate) static TORRENT_DELETIONS: Lazy<CounterVec> = Lazy::new(|| {
-    register_counter_vec!(
-        "torrent_deletion_count",
-        "Number of torrents that got deleted, per instance/policy",
-        &["transmission_url", "policy"]
-    )
-    .unwrap()
-});
-
-/// Adds a 1 to a `prometheus::core::GenericCounter` when it is dropped.
-pub(crate) struct FailureCounter<P: prometheus::core::Atomic>(
-    prometheus::core::GenericCounter<P>,
-    bool,
-);
-
-impl<P: prometheus::core::Atomic> FailureCounter<P> {
-    /// Create a failure counter that increments a prometheus counter unless told not to.
-    pub(crate) fn new(counter: prometheus::core::GenericCounter<P>) -> Self {
-        Self(counter, true)
-    }
-
-    /// Declare the operation a success, and don't increment the failure counter.
-    pub(crate) fn succeed(self) {
-        let mut fc = self;
-        fc.1 = false;
+impl Drop for TickDurationHandle {
+    fn drop(&mut self) {
+        if let Ok(duration) = self.started.elapsed() {
+            self.family
+                .get_or_create(&self.variant)
+                .observe(duration.as_millis() as f64);
+        }
     }
 }
 
-impl<P: prometheus::core::Atomic> Drop for FailureCounter<P> {
+pub(crate) struct FailureCountHandle {
+    family: Family<TransmissionLocation, Counter>,
+    variant: TransmissionLocation,
+    success: bool,
+}
+
+impl FailureCountHandle {
+    pub fn succeed(mut self) {
+        self.success = true;
+    }
+}
+
+impl Drop for FailureCountHandle {
     fn drop(&mut self) {
-        if self.1 {
-            self.0.inc();
+        if !self.success {
+            self.family.get_or_create(&self.variant).inc();
         }
     }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+struct TransmissionLocation {
+    transmission_url: String,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub(crate) struct Policy {
+    transmission_url: String,
+    policy: String,
+}
+
+impl Policy {
+    pub(crate) fn new_for(transmission_url: &str, policy: &str) -> Self {
+        Policy {
+            transmission_url: transmission_url.to_string(),
+            policy: policy.to_string(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct Metrics {
+    tick_duration: Family<TransmissionLocation, Histogram>,
+    tick_failure_counter: Family<TransmissionLocation, Counter>,
+    size_distribution: Family<Policy, Histogram>,
+    torrent_deletions: Family<Policy, Counter>,
+    total_count: Family<Policy, Gauge>,
+    total_size: Family<Policy, Gauge>,
+}
+
+impl Metrics {
+    /// Initialize and return a set of metrics registered on `registry`.
+    pub(crate) fn for_registry(registry: &mut Registry) -> Self {
+        let metrics = Self {
+            tick_duration: Family::new_with_constructor(|| {
+                Histogram::new(exponential_buckets(1.0, 1.5, 20))
+            }),
+            tick_failure_counter: Family::default(),
+            size_distribution: Family::new_with_constructor(|| {
+                Histogram::new(exponential_buckets(5e9, 2.0, 11))
+            }),
+            torrent_deletions: Family::default(),
+            total_count: Family::default(),
+            total_size: Family::default(),
+        };
+        registry.register(
+            "instance_fetch_duration_ms",
+            "Time it took gearbox-maintenance to fetch data from one transmission instance",
+            metrics.tick_duration.clone(),
+        );
+        registry.register(
+            "instance_fetch_failure_count",
+            "Number of times that fetching from the instance failed",
+            metrics.tick_failure_counter.clone(),
+        );
+        registry.register(
+            "torrent_size_bytes_historam",
+            "Histogram of torrent size managed by policy.",
+            metrics.size_distribution.clone(),
+        );
+        registry.register(
+            "torrent_deletion_count",
+            "Number of torrents that got deleted, per instance/policy",
+            metrics.torrent_deletions.clone(),
+        );
+        registry.register(
+            "torrent_count",
+            "Number of torrents, per transmission URL and policy.",
+            metrics.total_count.clone(),
+        );
+        registry.register(
+            "torrent_size_bytes",
+            "Total data size of torrents in bytes, per transmission URL and policy.",
+            metrics.total_size.clone(),
+        );
+
+        metrics
+    }
+
+    /// Return a histogram timer that tracks the duration it is in scope.
+    pub(crate) fn tick_duration(&self, url: &str) -> TickDurationHandle {
+        TickDurationHandle {
+            family: self.tick_duration.clone(),
+            variant: TransmissionLocation {
+                transmission_url: url.to_string(),
+            },
+            started: SystemTime::now(),
+        }
+    }
+
+    /// Return a [`FailureTracker`] that will record a failure when it goes out of scope.
+    pub(crate) fn tick_failure_tracker(&self, url: &str) -> FailureCountHandle {
+        FailureCountHandle {
+            family: self.tick_failure_counter.clone(),
+            variant: TransmissionLocation {
+                transmission_url: url.to_string(),
+            },
+            success: false,
+        }
+    }
+
+    /// Track a torrent's size on the size distribution histogram.
+    pub(crate) fn track_size(&self, policy: &Policy, size: usize) {
+        self.size_distribution
+            .get_or_create(policy)
+            .observe(size as f64);
+    }
+
+    /// Track a torrent deletion.
+    pub(crate) fn track_torrent_deletion(&self, policy: &Policy) {
+        self.torrent_deletions.get_or_create(policy).inc();
+    }
+
+    pub(crate) fn update_count(&self, policy: &Policy, count: usize) {
+        self.total_count.get_or_create(policy).set(count as i64);
+    }
+
+    pub(crate) fn update_size(&self, policy: &Policy, size: usize) {
+        self.total_size.get_or_create(policy).set(size as i64);
+    }
+}
+
+struct AppState {
+    pub registry: Registry,
+}
+
+async fn metrics_handler(State(state): State<Arc<Mutex<AppState>>>) -> impl IntoResponse {
+    let state = state.lock().await;
+    let mut buffer = String::new();
+    encode(&mut buffer, &state.registry).unwrap();
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            CONTENT_TYPE,
+            "application/openmetrics-text; version=1.0.0; charset=utf-8",
+        )
+        .body(Body::from(buffer))
+        .unwrap()
+}
+
+pub(crate) fn metrics_router(registry: Registry) -> Router {
+    let state = Arc::new(Mutex::new(AppState { registry }));
+
+    Router::new()
+        .route("/metrics", get(metrics_handler))
+        .with_state(state)
 }


### PR DESCRIPTION
The rust-prometheus crate is using a super outdated version of protobuf, and is only semi-maintained anymore. Let's switch to prometheus_client, the official library.